### PR TITLE
masstx.js script can be buggy in certain circumstances

### DIFF
--- a/manualmasstx.js
+++ b/manualmasstx.js
@@ -1,0 +1,70 @@
+/**
+ *  Simple script based on masstx.js.
+ *  It allows to send a mass transaction manually. 
+ *  The json data payload has to be defined in variable masstransactionpayment.
+ */
+var masstransactionpayment = JSON.parse('');
+
+var config = {
+    payoutfileprefix: 'ltoleaserpayouts',
+    node: 'http://localhost:6869',
+    apiKey: 'your api key'
+};
+
+const debug = true;
+const decimalpts = 8
+
+var fs = require('fs');
+var request = require('request');
+var newpayqueue = []
+
+function doPayment() {
+    if (debug) {
+        console.log("debug output:");
+        console.log("going to send out request with following masstransactionpayment:");
+        console.log(JSON.stringify(masstransactionpayment));
+    }
+
+    request.post({
+        url: config.node + '/transactions/sign',
+        json: masstransactionpayment,
+        headers: {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "api_key": !debug ? config.apiKey : ''
+        }
+    }, function(err, res) {
+        if (err || res.body.error) {
+            const error = err || res.body;
+
+            console.log(error);
+            
+            if(!debug) {
+                return;
+            }
+        }
+
+        request.post({
+            url: config.node + '/transactions/broadcast',
+            json: !debug ? res.body : {},
+            headers: {
+                "Accept": "application/json",
+                "Content-Type": "application/json"
+            }
+        }, function(err, res) {
+
+            if (err || res.body.error) {
+                const error = err || res.body;
+
+                console.log(error);
+                if(!debug) {
+                    return;
+                }
+            }
+
+            console.log("masstransfer done")
+        });
+    });
+}
+
+doPayment();

--- a/masstx.js
+++ b/masstx.js
@@ -294,19 +294,22 @@ var doPayment = function(payments, counter, batchid, nrofmasstransfers) {
                         headers: {
                             "Accept": "application/json",
                             "Content-Type": "application/json",
-                            "api_key": config.apiKey
+                            "api_key": !debug ? config.apiKey : ''
                         }
                     }, function(err, res) {
                         if (err || res.body.error) {
                             const error = err || res.body;
 
                             console.log(error);
-                            return;
+                            
+                            if(!debug) {
+                                return;
+                            }
                         }
 
                         request.post({
                             url: config.node + '/transactions/broadcast',
-                            json: res.body,
+                            json: !debug ? res.body : {},
                             headers: {
                                 "Accept": "application/json",
                                 "Content-Type": "application/json"
@@ -317,7 +320,9 @@ var doPayment = function(payments, counter, batchid, nrofmasstransfers) {
                                 const error = err || res.body;
 
                                 console.log(error);
-                                return;
+                                if(!debug) {
+                                    return;
+                                }
                             }
 
                             logmessage = "         " + batchid + "] - masstransfer " + masstransfercounterup +

--- a/masstx.js
+++ b/masstx.js
@@ -1,4 +1,3 @@
-
 /**
  *  Put your settings here, bare minimum:
  *      - node: address of your node in the form http://<ip>:<port>
@@ -6,7 +5,6 @@
  *
  *  That's it! Enjoy
  */
-
 var config = {
     payoutfileprefix: 'ltoleaserpayouts',
     node: 'http://localhost:6869',
@@ -17,8 +15,8 @@ const paymentqueuefile = 'payqueue.dat'
 const transactiontimeout = 1500 //Msecs to wait between every transaction posted
 const paymentsdonedir = 'paymentsDone/'
 const maxmasstransfertxs = 100 //Maximum nr of transactions that fit in 1 masstransfer
-const coins = [ "lto" ] //Which coins we take into consideration for masstransfers
-const transferfee     = 100000000
+const coins = ["lto"] //Which coins we take into consideration for masstransfers
+const transferfee = 100000000
 const masstransferfee = 10000000
 const masstransferversion = 1
 const masstransfertype = 11
@@ -30,8 +28,9 @@ const masstransfertype = 11
 // And then restart the payment process. That's it. No more changes needed.
 // You can leave it as is and do not have to change it back to 0
 const crashconfig = {
-	batchidstart: '0',
-	transactionstart: '0' }
+    batchidstart: '0',
+    transactionstart: '0'
+}
 
 var fs = require('fs');
 var request = require('request');
@@ -39,116 +38,119 @@ var newpayqueue = []
 var jobs
 
 /*
-** Method to do some tests before program run any further
-** This is the first function that runs
-*/
-function testcases () {
+ ** Method to do some tests before program run any further
+ ** This is the first function that runs
+ */
+function testcases() {
 
-	if ( !fs.existsSync(paymentsdonedir) ) {
-		fs.mkdirSync(paymentsdonedir, 0744) //Create archival DIR
-		getpayqueue(start);
-	}
-	else if ( !fs.existsSync(paymentqueuefile) ) {
-		console.log("Missing file " + paymentqueuefile + "! Run collector session first. Goodbye")
-	}
-	else if ( JSON.parse(fs.readFileSync(paymentqueuefile)).length == 0 ) {
-		console.log("Empty payqueue! Nothing to pay, goodbye :-)")
-	}
-	else {
-		getpayqueue(start);
-	}
+    if (!fs.existsSync(paymentsdonedir)) {
+        fs.mkdirSync(paymentsdonedir, 0744) //Create archival DIR
+        getpayqueue(start);
+    } else if (!fs.existsSync(paymentqueuefile)) {
+        console.log("Missing file " + paymentqueuefile + "! Run collector session first. Goodbye")
+    } else if (JSON.parse(fs.readFileSync(paymentqueuefile)).length == 0) {
+        console.log("Empty payqueue! Nothing to pay, goodbye :-)")
+    } else {
+        getpayqueue(start);
+    }
 }
 
 /*
-** Method to get only the batches from the paymentqueue file that are non-empty (with payouts)
-** The batchid's are pushed into a new array
-** @callback: returns the batchid
-*/
-function getnonemptybatches (batchid) {
-	batchpaymentarray = JSON.parse(fs.readFileSync(config.payoutfileprefix + batchid + '.json'),toString())
-	if ( batchpaymentarray.length == 0 ) {
-		console.log("[BatchID " + batchid + "] empty, no payouts!")
-		updatepayqueuefile(newpayqueue,batchid)
-	}
-	return !batchpaymentarray.length == 0 
+ ** Method to get only the batches from the paymentqueue file that are non-empty (with payouts)
+ ** The batchid's are pushed into a new array
+ ** @callback: returns the batchid
+ */
+function getnonemptybatches(batchid) {
+    batchpaymentarray = JSON.parse(fs.readFileSync(config.payoutfileprefix + batchid + '.json'), toString())
+    if (batchpaymentarray.length == 0) {
+        console.log("[BatchID " + batchid + "] empty, no payouts!")
+        updatepayqueuefile(newpayqueue, batchid)
+    }
+    return !batchpaymentarray.length == 0
 }
 
 /*
-** Method to collect all payouts per batch, read from the payoutfile
-** It cycles through the paymentqueue and executes the myfunction,
-** which is the function 'start'
-** The actual payout transactions are done by the 'start' function
-** In the start function transactions are delayed by timer 'transactiontimeout' (1000)
-** The timeoutarray ensures that the transactions for the next batch are delayed,
-** with the transactiondelay of the previous batches. This is needed because the
-** forEach function executes the 'myfunction' as fast as it can, so this will create
-** parallel processing.
-*/
-function getpayqueue (myfunction) {
+ ** Method to collect all payouts per batch, read from the payoutfile
+ ** It cycles through the paymentqueue and executes the myfunction,
+ ** which is the function 'start'
+ ** The actual payout transactions are done by the 'start' function
+ ** In the start function transactions are delayed by timer 'transactiontimeout' (1000)
+ ** The timeoutarray ensures that the transactions for the next batch are delayed,
+ ** with the transactiondelay of the previous batches. This is needed because the
+ ** forEach function executes the 'myfunction' as fast as it can, so this will create
+ ** parallel processing.
+ */
+function getpayqueue(myfunction) {
 
-	var payqueuearray = JSON.parse(fs.readFileSync(paymentqueuefile));
-	jobs = payqueuearray.length
-	var backuppayqueue = fs.writeFileSync(paymentqueuefile+".bak",fs.readFileSync(paymentqueuefile))	//Create backup of queuefile
-	var batchpaymentarray
-	var cleanpayqueuearray = payqueuearray.filter(getnonemptybatches)	// This var is the payqueue array without zero pay jobs
-	newpayqueue = cleanpayqueuearray
-	var txdelay = 0
-	var timeoutarray = [];
-	timeoutarray[0] = 0;
+    var payqueuearray = JSON.parse(fs.readFileSync(paymentqueuefile));
+    jobs = payqueuearray.length
+    var backuppayqueue = fs.writeFileSync(paymentqueuefile + ".bak", fs.readFileSync(paymentqueuefile)) //Create backup of queuefile
+    var batchpaymentarray
+    var cleanpayqueuearray = payqueuearray.filter(getnonemptybatches) // This var is the payqueue array without zero pay jobs
+    newpayqueue = cleanpayqueuearray
+    var txdelay = 0
+    var timeoutarray = [];
+    timeoutarray[0] = 0;
 
-	cleanpayqueuearray.forEach ( function ( batchid, index ) {  //remark: index in array starts at 0!
+    cleanpayqueuearray.forEach(function(batchid, index) { //remark: index in array starts at 0!
 
-                payoutfilename = config.payoutfileprefix + batchid + '.json'
-		batchpaymentarray = JSON.parse(fs.readFileSync(payoutfilename),toString())	//All transaction details current batch
-		var ltotransactions = 0
-		var transactioncount = parseInt(batchpaymentarray.length)	//how many transactions current batch		
-		var nrofmasstransfers //How many masstransfers needed for all payments
-		var txdelay	//total time needed for all masstransfers in current batch
+        payoutfilename = config.payoutfileprefix + batchid + '.json'
+        batchpaymentarray = JSON.parse(fs.readFileSync(payoutfilename), toString()) //All transaction details current batch
+        var ltotransactions = 0
+        var transactioncount = parseInt(batchpaymentarray.length) //how many transactions current batch		
+        var nrofmasstransfers //How many masstransfers needed for all payments
+        var txdelay //total time needed for all masstransfers in current batch
 
-		batchpaymentarray.forEach( function (asset,index) {
-                	ltotransactions++
-		})
+        batchpaymentarray.forEach(function(asset, index) {
+            ltotransactions++
+        })
 
-		nrofmasstransfers = Math.ceil(ltotransactions/maxmasstransfertxs)
-		txdelay = nrofmasstransfers*transactiontimeout
-		timeoutarray[index+1] = timeoutarray[index] + txdelay
+        nrofmasstransfers = Math.ceil(ltotransactions / maxmasstransfertxs)
+        txdelay = nrofmasstransfers * transactiontimeout
+        timeoutarray[index + 1] = timeoutarray[index] + txdelay
 
-		setTimeout(myfunction, timeoutarray[index], batchpaymentarray, batchid, nrofmasstransfers) 
+        setTimeout(myfunction, timeoutarray[index], batchpaymentarray, batchid, nrofmasstransfers)
 
-        }) //End forEach
+    }) //End forEach
 
 } //End function getpayqueue
 
-function updatepayqueuefile (array, batchid) {
+function updatepayqueuefile(array, batchid) {
 
-	jobs-- //Count down everytime a job is done
-	
-	if ( batchpaymentarray.length == 0 ) { printline = "\nRemoved batch " + batchid + " from the payqueue and successfully updated file " + paymentqueuefile + "!\n" }
-	else { printline = "\nAll payments done for batch " + batchid + ". Removed from the payqueue and succesfully updated file " + paymentqueuefile + "!\n" }
+    jobs-- //Count down everytime a job is done
 
-	array.shift(console.log(printline)) //Strip batchid from array
+    if (batchpaymentarray.length == 0) {
+        printline = "\nRemoved batch " + batchid + " from the payqueue and successfully updated file " + paymentqueuefile + "!\n"
+    } else {
+        printline = "\nAll payments done for batch " + batchid + ". Removed from the payqueue and succesfully updated file " + paymentqueuefile + "!\n"
+    }
 
-		fs.writeFile(paymentqueuefile, JSON.stringify(array), {}, function(err) {
-        		if (!err) { } else { console.log("Warning, errors writing payqueue file!\n",err); }
-    		});
+    array.shift(console.log(printline)) //Strip batchid from array
 
-		fs.renameSync(config.payoutfileprefix + batchid + ".json", paymentsdonedir + config.payoutfileprefix + batchid + ".json")
-		fs.renameSync(config.payoutfileprefix + batchid + ".html", paymentsdonedir + config.payoutfileprefix + batchid + ".html")
-		fs.renameSync(config.payoutfileprefix + batchid + ".log", paymentsdonedir + config.payoutfileprefix + batchid + ".log")
+    fs.writeFile(paymentqueuefile, JSON.stringify(array), {}, function(err) {
+        if (!err) {} else {
+            console.log("Warning, errors writing payqueue file!\n", err);
+        }
+    });
 
-		console.log("Moved leaserpayoutfiles of batch " + batchid + " to directory " + paymentsdonedir + " for archival purposes.")
-		console.log("  - " + config.payoutfileprefix + batchid + ".json => " + paymentsdonedir + config.payoutfileprefix + batchid + ".json")
-		console.log("  - " + config.payoutfileprefix + batchid + ".html => " + paymentsdonedir + config.payoutfileprefix + batchid + ".html")
-		console.log("  - " + config.payoutfileprefix + batchid + ".log => " + paymentsdonedir + config.payoutfileprefix + batchid + ".log")
+    fs.renameSync(config.payoutfileprefix + batchid + ".json", paymentsdonedir + config.payoutfileprefix + batchid + ".json")
+    fs.renameSync(config.payoutfileprefix + batchid + ".html", paymentsdonedir + config.payoutfileprefix + batchid + ".html")
+    fs.renameSync(config.payoutfileprefix + batchid + ".log", paymentsdonedir + config.payoutfileprefix + batchid + ".log")
 
-		if ( batchpaymentarray.length !== 0 ) {
-			console.log("\nAppended payment masstransaction logs to " + config.payoutfileprefix + batchid + ".log for reference.") }
+    console.log("Moved leaserpayoutfiles of batch " + batchid + " to directory " + paymentsdonedir + " for archival purposes.")
+    console.log("  - " + config.payoutfileprefix + batchid + ".json => " + paymentsdonedir + config.payoutfileprefix + batchid + ".json")
+    console.log("  - " + config.payoutfileprefix + batchid + ".html => " + paymentsdonedir + config.payoutfileprefix + batchid + ".html")
+    console.log("  - " + config.payoutfileprefix + batchid + ".log => " + paymentsdonedir + config.payoutfileprefix + batchid + ".log")
 
-		console.log("\n======================= batch " + batchid + " all done =======================\n")
-	
-	  	if ( jobs == 0 ) { //Processed all jobs in the payqueue
-		        console.log(" Finished payments for all jobs in the payqueue. All done!\n")
-                }
+    if (batchpaymentarray.length !== 0) {
+        console.log("\nAppended payment masstransaction logs to " + config.payoutfileprefix + batchid + ".log for reference.")
+    }
+
+    console.log("\n======================= batch " + batchid + " all done =======================\n")
+
+    if (jobs == 0) { //Processed all jobs in the payqueue
+        console.log(" Finished payments for all jobs in the payqueue. All done!\n")
+    }
 }
 
 /**
@@ -160,11 +162,10 @@ function updatepayqueuefile (array, batchid) {
 var start = function(jsonarray, queueid, nrofmasstransfers) {
     var payments = jsonarray;
 
-    if ( crashconfig.batchidstart == queueid && crashconfig.transactionstart > 0 ) { //start after crash occured
-	doPayment(payments, crashconfig.transactionstart, queueid)	//Start payment process after crash occured
-    }
-    else {	//Start normal payment process
-	doPayment(payments, 0, queueid, nrofmasstransfers)
+    if (crashconfig.batchidstart == queueid && crashconfig.transactionstart > 0) { //start after crash occured
+        doPayment(payments, crashconfig.transactionstart, queueid) //Start payment process after crash occured
+    } else { //Start normal payment process
+        doPayment(payments, 0, queueid, nrofmasstransfers)
     }
 };
 
@@ -177,182 +178,217 @@ var start = function(jsonarray, queueid, nrofmasstransfers) {
  * @param counter: the current payment that should be done (not used for now, always 0)
  * @param batchid: the payment batchid number from the payqueue
  * @param nrofmasstransfers: the #masstransfers to be done
-**/
+ **/
 var doPayment = function(payments, counter, batchid, nrofmasstransfers) {
 
-	var masstxsdone = 0 //counter to detect when all masstransfers are done for one payment batch
-	var payment = {} //Payment object with all transactions for lto
-	var masstxarray = [] //array with all transactions for 1 masstransfer
-        var masstxpayment = {} //JSON object used for actual payment POST
-	var decimalpts //how many decimals for a token
-	var delayarray = [] //array to set timeout time related to all transactions to be done
-	var logobject = "" //object to add to batchlogfile
-	var transfercostbatch = 0 //transfercost for all masstransfers in a batch
-        delayarray[0] = 0 //timeout for first asset will be zero
+    var masstxsdone = 0 //counter to detect when all masstransfers are done for one payment batch
+    var payment = {} //Payment object with all transactions for lto
+    var masstxarray = [] //array with all transactions for 1 masstransfer
+    var masstxpayment = {} //JSON object used for actual payment POST
+    var decimalpts //how many decimals for a token
+    var delayarray = [] //array to set timeout time related to all transactions to be done
+    var logobject = "" //object to add to batchlogfile
+    var transfercostbatch = 0 //transfercost for all masstransfers in a batch
+    delayarray[0] = 0 //timeout for first asset will be zero
 
-	masstransferobject(payments, function(cb) { payment = cb })      //VAR to construct masstransfer array, callback array with all transactions
+    masstransferobject(payments, function(cb) {
+        payment = cb
+    }) //VAR to construct masstransfer array, callback array with all transactions
 
-	coins.forEach( function (asset,index) {
+    coins.forEach(function(asset, index) {
 
-		if ( asset in payment ) { //Found relevant coin in payment object
+        if (asset in payment) { //Found relevant coin in payment object
 
-			var assettxs = payment[asset] //Array with all transactions
-			var totaltxs = assettxs.length //Total number of transactions for one asset
-			var masstransfers = Math.ceil(totaltxs/maxmasstransfertxs) //How many masstransfers needed for all payments
-			var transactiondelay = masstransfers*transactiontimeout //total time needed for all masstransfers current asset
-			var ii = 0 //Counter for all transactions
+            var assettxs = payment[asset] //Array with all transactions
+            var totaltxs = assettxs.length //Total number of transactions for one asset
+            var masstransfers = Math.ceil(totaltxs / maxmasstransfertxs) //How many masstransfers needed for all payments
+            var transactiondelay = masstransfers * transactiontimeout //total time needed for all masstransfers current asset
+            var ii = 0 //Counter for all transactions
 
-			delayarray[index+1] = delayarray[index] + transactiondelay //Set timeout for next asset
+            delayarray[index + 1] = delayarray[index] + transactiondelay //Set timeout for next asset
 
-			setTimeout( function() { //Start function actions for an Asset
+            setTimeout(function() { //Start function actions for an Asset
 
-				var assetamount = 0
-				var masstransfercounter = masstransfers
-				var loop = totaltxs
-				var onemasstransferamount
-				var assetId = ''
-				var masstransfercounterup = 0
-				var logmessage
+                var assetamount = 0
+                var masstransfercounter = masstransfers
+                var loop = totaltxs
+                var onemasstransferamount
+                var assetId = ''
+                var masstransfercounterup = 0
+                var logmessage
 
-				if ( asset == 'lto' ) { decimalpts = 8 }
- 				if ( asset !== 'lto' ) { var assetId = payment["Common"][asset + "assetId"] }
-
-				var masstransactionpayment = {
- 								"version": masstransferversion,
-								"type": masstransfertype,
-								"sender": payment.Common.sender
-				}
-
-				if ( asset !== 'lto' ) { masstransactionpayment.assetId = assetId } //Add assetId to json if asset is NOT lto
-
-				assettxs.forEach(function (asset) { assetamount += asset.amount }) //How much fees total for an asset
-
-				if ( asset == 'lto' ) { var text = "fee rewards" } else { var text = asset }
-
-				logmessage = "[BatchID " + batchid + "] Found " + totaltxs + " '" + asset + "' transactions, total " + assetamount/Math.pow(10,decimalpts) +
-                                            " " + text + ", will do " + masstransfers + " masstransfers."
-
-				logobject += logmessage + "\n"
-
-				console.log(logmessage)
-
-				for ( var cnt = 0; cnt < masstransfers; cnt++ ) { //Loop through all masstransfers for one asset
-
-					masstxarray = []
-					onemasstransferamount = 0
-					timeout = cnt*transactiontimeout //timeout for masstransfers
-
-					setTimeout ( function () { //Start function masstransfers
-
-						if ( loop > maxmasstransfertxs ) { loop = maxmasstransfertxs } 
-
-						for ( var i = 0; i < loop; i++ ) { //Loop trough all transactions, max 'const masstransfer or #txs if 1 masstransfer
-
-							masstxarray.push(assettxs[ii]) //cycle through all transactions
-							onemasstransferamount += assettxs[ii].amount //how many fees in one masstransfer
-							ii++ //counter for all transactions
-						}
-
-						masstransactionpayment['transfers'] = masstxarray //add transactions to payment json object
-						masstransfercounter-- //For breaking the for loop
-						masstransfercounterup++
-						masstransfercost = transferfee + (masstransferfee * masstxarray.length)
-						masstransactionpayment.fee = masstransfercost //Add fee to masstransfer json object
-
-						if ( totaltxs > maxmasstransfertxs ) { //calc number of transactions for last masstransfer
-							if ( masstransfercounter == 1 ) { loop = totaltxs - (masstransfers-1)*maxmasstransfertxs }
-						}
-						if ( masstransfers == 1 ) { timeout = 0 } else { timeout = transactiontimeout }
-
-						//Put here the actual POST function for a masstransfer
-            request.post({
-              url: config.node + '/transactions/sign',
-              json: masstransactionpayment,
-              headers: {"Accept": "application/json", "Content-Type": "application/json", "api_key": config.apiKey}
-            }, function (err, res) {
-              if (err || res.body.error) {
-                const error = err || res.body;
-
-                console.log(error);
-                return;
-              }
-
-              request.post({
-                url: config.node + '/transactions/broadcast',
-                json: res.body,
-                headers: {"Accept": "application/json", "Content-Type": "application/json"}
-              }, function (err, res) {
-
-                if (err || res.body.error) {
-                  const error = err || res.body;
-
-                  console.log(error);
-                  return;
+                if (asset == 'lto') {
+                    decimalpts = 8
+                }
+                if (asset !== 'lto') {
+                    var assetId = payment["Common"][asset + "assetId"]
                 }
 
-                logmessage = "         " + batchid + "] - masstransfer " + masstransfercounterup +
-                  " for " + asset + " done! Send " + onemasstransferamount / Math.pow(10, decimalpts) +
-                  " " + asset + " with " + masstxarray.length + " transactions in it." +
-                  " Cost " + masstransactionpayment.fee / Math.pow(10, 8)
+                var masstransactionpayment = {
+                    "version": masstransferversion,
+                    "type": masstransfertype,
+                    "sender": payment.Common.sender
+                }
+
+                if (asset !== 'lto') {
+                    masstransactionpayment.assetId = assetId
+                } //Add assetId to json if asset is NOT lto
+
+                assettxs.forEach(function(asset) {
+                    assetamount += asset.amount
+                }) //How much fees total for an asset
+
+                if (asset == 'lto') {
+                    var text = "fee rewards"
+                } else {
+                    var text = asset
+                }
+
+                logmessage = "[BatchID " + batchid + "] Found " + totaltxs + " '" + asset + "' transactions, total " + assetamount / Math.pow(10, decimalpts) +
+                    " " + text + ", will do " + masstransfers + " masstransfers."
+
+                logobject += logmessage + "\n"
 
                 console.log(logmessage)
 
-                logobject += logmessage + "\n"
-                masstxarray = []
-                onemasstransferamount = 0
-                masstxsdone++
-                transfercostbatch += masstransactionpayment.fee / Math.pow(10, 8)
+                for (var cnt = 0; cnt < masstransfers; cnt++) { //Loop through all masstransfers for one asset
 
-                if (masstxsdone == nrofmasstransfers) { //Finished all masstransfers for one batch!
+                    masstxarray = []
+                    onemasstransferamount = 0
+                    timeout = cnt * transactiontimeout //timeout for masstransfers
 
-                  console.log("\nTotal masstransfercosts: " + transfercostbatch + " lto.")
+                    setTimeout(function() { //Start function masstransfers
 
-                  fs.appendFileSync(config.payoutfileprefix + batchid + ".log",
-                    "\n======= masstx payment log [" + (new Date()) + "] =======\n" + logobject +
-                    "\nTotal masstransfercosts: " + transfercostbatch + " lto.\n" +
-                    "All payments done for batch " + batchid + ".\n")
+                        if (loop > maxmasstransfertxs) {
+                            loop = maxmasstransfertxs
+                        }
 
-                  updatepayqueuefile(newpayqueue, batchid)
-                }
-              });
-            });
-					}, timeout) //End function masstransfers
-				} //End for all masstransfers loop
-			}, delayarray[index]) //End function actions for an Asset
-		} //End if ( asset in payment )
-	}) //End loop coins.forEach
+                        for (var i = 0; i < loop; i++) { //Loop trough all transactions, max 'const masstransfer or #txs if 1 masstransfer
+
+                            masstxarray.push(assettxs[ii]) //cycle through all transactions
+                            onemasstransferamount += assettxs[ii].amount //how many fees in one masstransfer
+                            ii++ //counter for all transactions
+                        }
+
+                        masstransactionpayment['transfers'] = masstxarray //add transactions to payment json object
+                        masstransfercounter-- //For breaking the for loop
+                        masstransfercounterup++
+                        masstransfercost = transferfee + (masstransferfee * masstxarray.length)
+                        masstransactionpayment.fee = masstransfercost //Add fee to masstransfer json object
+
+                        if (totaltxs > maxmasstransfertxs) { //calc number of transactions for last masstransfer
+                            if (masstransfercounter == 1) {
+                                loop = totaltxs - (masstransfers - 1) * maxmasstransfertxs
+                            }
+                        }
+                        if (masstransfers == 1) {
+                            timeout = 0
+                        } else {
+                            timeout = transactiontimeout
+                        }
+
+                        //Put here the actual POST function for a masstransfer
+                        request.post({
+                            url: config.node + '/transactions/sign',
+                            json: masstransactionpayment,
+                            headers: {
+                                "Accept": "application/json",
+                                "Content-Type": "application/json",
+                                "api_key": config.apiKey
+                            }
+                        }, function(err, res) {
+                            if (err || res.body.error) {
+                                const error = err || res.body;
+
+                                console.log(error);
+                                return;
+                            }
+
+                            request.post({
+                                url: config.node + '/transactions/broadcast',
+                                json: res.body,
+                                headers: {
+                                    "Accept": "application/json",
+                                    "Content-Type": "application/json"
+                                }
+                            }, function(err, res) {
+
+                                if (err || res.body.error) {
+                                    const error = err || res.body;
+
+                                    console.log(error);
+                                    return;
+                                }
+
+                                logmessage = "         " + batchid + "] - masstransfer " + masstransfercounterup +
+                                    " for " + asset + " done! Send " + onemasstransferamount / Math.pow(10, decimalpts) +
+                                    " " + asset + " with " + masstxarray.length + " transactions in it." +
+                                    " Cost " + masstransactionpayment.fee / Math.pow(10, 8)
+
+                                console.log(logmessage)
+
+                                logobject += logmessage + "\n"
+                                masstxarray = []
+                                onemasstransferamount = 0
+                                masstxsdone++
+                                transfercostbatch += masstransactionpayment.fee / Math.pow(10, 8)
+
+                                if (masstxsdone == nrofmasstransfers) { //Finished all masstransfers for one batch!
+
+                                    console.log("\nTotal masstransfercosts: " + transfercostbatch + " lto.")
+
+                                    fs.appendFileSync(config.payoutfileprefix + batchid + ".log",
+                                        "\n======= masstx payment log [" + (new Date()) + "] =======\n" + logobject +
+                                        "\nTotal masstransfercosts: " + transfercostbatch + " lto.\n" +
+                                        "All payments done for batch " + batchid + ".\n")
+
+                                    updatepayqueuefile(newpayqueue, batchid)
+                                }
+                            });
+                        });
+                    }, timeout) //End function masstransfers
+                } //End for all masstransfers loop
+            }, delayarray[index]) //End function actions for an Asset
+        } //End if ( asset in payment )
+    }) //End loop coins.forEach
 } //End var doPayment
 
 /* This var will create the masstransferarray for lto
  * @param paymentarray: the array with all lease recipients with amounts
  * @param cb: the array transfers is returned to the caller
-*/
-var masstransferobject = function (paymentarray, cb) {
-	var transfers = {}
-	var lto = 'lto'
-	var common = 'Common'
-	var ltoamount = 0
+ */
+var masstransferobject = function(paymentarray, cb) {
+    var transfers = {}
+    var lto = 'lto'
+    var common = 'Common'
+    var ltoamount = 0
 
-	transfers[common] = {}
-	transfers[lto] = []	//empty array where we will push lto recipients and amounts
+    transfers[common] = {}
+    transfers[lto] = [] //empty array where we will push lto recipients and amounts
 
-	paymentarray.forEach (function(asset, index) {
+    paymentarray.forEach(function(asset, index) {
 
-		if ( asset.sender ) { if ( !transfers[common].sender == true ) { transfers[common].sender = asset.sender } }
+        if (asset.sender) {
+            if (!transfers[common].sender == true) {
+                transfers[common].sender = asset.sender
+            }
+        }
 
-		if ( !asset.assetId ) { //No assetId means found lto transaction
+        if (!asset.assetId) { //No assetId means found lto transaction
 
-			var ltodata = {	"recipient" : asset.recipient,
-						"amount" : asset.amount }
+            var ltodata = {
+                "recipient": asset.recipient,
+                "amount": asset.amount
+            }
 
-			ltoamount += asset.amount
-			transfers[common].ltoamount = ltoamount
-			transfers[lto].push(ltodata)
+            ltoamount += asset.amount
+            transfers[common].ltoamount = ltoamount
+            transfers[lto].push(ltodata)
 
-		} 
-	})
-	cb(transfers);
-//console.log(transfers)
+        }
+    })
+    cb(transfers);
+    //console.log(transfers)
 }
 
 testcases();

--- a/masstx.js
+++ b/masstx.js
@@ -209,22 +209,22 @@ var doPayment = function(payments, counter, batchid, nrofmasstransfers) {
 
             setTimeout(function() { //Start function actions for an Asset
 
-                var assetamount = 0
-                var masstransfercounter = masstransfers
-                var loop = totaltxs
-                var onemasstransferamount
-                var assetId = ''
-                var masstransfercounterup = 0
-                var logmessage
+                let assetamount = 0
+                let masstransfercounter = masstransfers
+                let loop = totaltxs
+                
+                let assetId = ''
+                let masstransfercounterup = 0;
+                let logmessage
 
                 if (asset == 'lto') {
                     decimalpts = 8
                 }
                 if (asset !== 'lto') {
-                    var assetId = payment["Common"][asset + "assetId"]
+                    let assetId = payment["Common"][asset + "assetId"]
                 }
 
-                var masstransactionpayment = {
+                let masstransactionpayment = {
                     "version": masstransferversion,
                     "type": masstransfertype,
                     "sender": payment.Common.sender
@@ -251,11 +251,11 @@ var doPayment = function(payments, counter, batchid, nrofmasstransfers) {
 
                 console.log(logmessage)
 
-                for (var cnt = 0; cnt < masstransfers; cnt++) { //Loop through all masstransfers for one asset
+                for (let cnt = 0; cnt < masstransfers; cnt++) { //Loop through all masstransfers for one asset
 
                     // without proper scope definition (let), the content of that variable will be wrong
                     let masstxarray = [];
-                    onemasstransferamount = 0;
+                    let onemasstransferamount = 0;
 
                     if (loop > maxmasstransfertxs) {
                         loop = maxmasstransfertxs;
@@ -273,7 +273,8 @@ var doPayment = function(payments, counter, batchid, nrofmasstransfers) {
                     masstransfercounterup++
                     masstransfercost = transferfee + (masstransferfee * masstxarray.length)
                     masstransactionpayment.fee = masstransfercost //Add fee to masstransfer json object
-
+                    let fee = masstransactionpayment.fee;
+                    
                     if (totaltxs > maxmasstransfertxs) { //calc number of transactions for last masstransfer
                         if (masstransfercounter == 1) {
                             loop = totaltxs - (masstransfers - 1) * maxmasstransfertxs
@@ -325,10 +326,10 @@ var doPayment = function(payments, counter, batchid, nrofmasstransfers) {
                                 }
                             }
 
-                            logmessage = "         " + batchid + "] - masstransfer " + masstransfercounterup +
+                            logmessage = "         " + batchid + "] - masstransfer " + (cnt+1) +
                                 " for " + asset + " done! Send " + onemasstransferamount / Math.pow(10, decimalpts) +
                                 " " + asset + " with " + masstxarray.length + " transactions in it." +
-                                " Cost " + masstransactionpayment.fee / Math.pow(10, 8)
+                                " Cost " + fee / Math.pow(10, 8)
 
                             console.log(logmessage)
 
@@ -336,7 +337,7 @@ var doPayment = function(payments, counter, batchid, nrofmasstransfers) {
                             masstxarray = []
                             onemasstransferamount = 0
                             masstxsdone++
-                            transfercostbatch += masstransactionpayment.fee / Math.pow(10, 8)
+                            transfercostbatch += fee / Math.pow(10, 8)
 
                             if (masstxsdone == nrofmasstransfers) { //Finished all masstransfers for one batch!
 


### PR DESCRIPTION
My situation was:
* Payout of 105 leasers
* node checkPaymentsFile.js correctly reported that it will be done in two mass transactions: 100 + 5 with total cost of 12.5 LTO
* node masstx.tx failed with error
* LTO explorer showed only one tx with 100 recipients executed. The remaining one with 5 was missing.
* See attached logs.txt for output of both commands 'node checkPaymentsFile.js' and 'node masstx.js':
* [logs.txt](https://github.com/jayjaynl/LTO_LPoSDistributor/files/7070571/logs.txt)

My interpretation is, that the node API didn't repsond in time and so the masstx.js tried the next batch because of that setTimeout-flow-handling.
In addition to that, the scope of the variables was defined incorrectly and this had lead to the situation where the second transaction-payload data contained all 105 items. This failed obviously since the max masstx recipient number is 100.

I've solved it by removing the setTimeout part completely. I'm not an JS expert, but using setTimeout for such kind of flow control seems not be the correct approach. And I've also set scope of relevant variables correcly with "let" instead of "var".

Also changed:
* Added debug mode with some log output for analysing the payout payload before doing the real transaction
* Formatting of the code
* Adding a helper script for executing manuall masstxs (optional)

Testing:
* I've did one productive run of the new masstx.js with 108 payouts. It worked successfully.
