### PR TITLE
Change `api_key` header to `X-API-Key`.

### DIFF
--- a/massPayment.js
+++ b/massPayment.js
@@ -154,7 +154,7 @@ var doPayment = function(payments, counter, batchid) {
 	setTimeout(function() {
 		request.post({  url: config.node + '/assets/transfer',
 				json: payment,
-				headers: { "Accept": "application/json", "Content-Type": "application/json", "api_key": config.apiKey }
+				headers: { "Accept": "application/json", "Content-Type": "application/json", "X-API-Key": config.apiKey }
 			     }, function(err) {
             				if (err) {
                 				console.log(err);

--- a/masstx.js
+++ b/masstx.js
@@ -268,7 +268,7 @@ var doPayment = function(payments, counter, batchid, nrofmasstransfers) {
             request.post({
               url: config.node + '/transactions/sign',
               json: masstransactionpayment,
-              headers: {"Accept": "application/json", "Content-Type": "application/json", "api_key": config.apiKey}
+              headers: {"Accept": "application/json", "Content-Type": "application/json", "X-API-Key": config.apiKey}
             }, function (err, res) {
               if (err || res.body.error) {
                 const error = err || res.body;


### PR DESCRIPTION
Fix for LTO public node v1.5.2.
The `api_key` header was deprecated since v1.0 and has been removed in v1.5.2.
The `X-API-Key` header works in all version.

See ltonetwork/lto-public-chain@b6a43af6d42adf85968a3b965154a7cb98319de8